### PR TITLE
Revert "src.pro: fix target and header path"

### DIFF
--- a/src/src.pro
+++ b/src/src.pro
@@ -16,9 +16,9 @@ HEADERS += \
     state.hpp \
     agent.hpp
 
-target.path = $$PREFIX/usr/lib
+target.path = $$PREFIX/lib
 
-headers.path = $$PREFIX/usr/include/updatehubagent
+headers.path = $$PREFIX/include/updatehubagent
 headers.files = statechangelistener.hpp state.hpp agent.hpp
 
 QMAKE_PKGCONFIG_NAME = updatehubagent


### PR DESCRIPTION
This reverts commit 1d9ecaef18cfec70d4404e6e5a1e885aefb3bbeb.

Fix the installed-vs-shipped QA issue:

Files/directories were installed but not shipped in any package:
  /usr/usr/include
  /usr/usr/lib/libupdatehubagent.so.1.0.0
  /usr/usr/lib/libupdatehubagent.so.1
  /usr/usr/lib/libupdatehubagent.so
  /usr/usr/lib/libupdatehubagent.so.1.0
  /usr/usr/lib/pkgconfig
  /usr/usr/lib/pkgconfig/updatehubagent.pc
  /usr/usr/include/updatehubagent
  /usr/usr/include/updatehubagent/agent.hpp
  /usr/usr/include/updatehubagent/state.hpp
  /usr/usr/include/updatehubagent/statechangelistener.hpp

Instead of hard-coding `/usr` in PREFIX variable, allow the user
to override the install location.

Signed-off-by: Luis Gustavo S. Barreto <gustavo@ossystems.com.br>